### PR TITLE
Remove method duplication

### DIFF
--- a/Keychain.xcodeproj/xcshareddata/xcschemes/Keychain-Mac.xcscheme
+++ b/Keychain.xcodeproj/xcshareddata/xcschemes/Keychain-Mac.xcscheme
@@ -15,7 +15,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "BDA447E11C294B45003FDEAD"
-               BuildableName = "Keychain-Mac.framework"
+               BuildableName = "Keychain.framework"
                BlueprintName = "Keychain-Mac"
                ReferencedContainer = "container:Keychain.xcodeproj">
             </BuildableReference>
@@ -43,7 +43,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "BDA447E11C294B45003FDEAD"
-            BuildableName = "Keychain-Mac.framework"
+            BuildableName = "Keychain.framework"
             BlueprintName = "Keychain-Mac"
             ReferencedContainer = "container:Keychain.xcodeproj">
          </BuildableReference>
@@ -65,7 +65,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "BDA447E11C294B45003FDEAD"
-            BuildableName = "Keychain-Mac.framework"
+            BuildableName = "Keychain.framework"
             BlueprintName = "Keychain-Mac"
             ReferencedContainer = "container:Keychain.xcodeproj">
          </BuildableReference>
@@ -83,7 +83,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "BDA447E11C294B45003FDEAD"
-            BuildableName = "Keychain-Mac.framework"
+            BuildableName = "Keychain.framework"
             BlueprintName = "Keychain-Mac"
             ReferencedContainer = "container:Keychain.xcodeproj">
          </BuildableReference>

--- a/Source/Shared/Keychain.swift
+++ b/Source/Shared/Keychain.swift
@@ -13,11 +13,7 @@ public struct Keychain {
 
   // MARK: - Public methods
 
-  public static func password(forAccount account: String, service: String = bundleIdentifier) -> String {
-    return password(forAccount: account, service: service, accessGroup: "")
-  }
-  
-  public static func password(forAccount account: String, service: String = bundleIdentifier, accessGroup: String) -> String {
+  public static func password(forAccount account: String, service: String = bundleIdentifier, accessGroup: String = "") -> String {
     guard !service.isEmpty && !account.isEmpty else { return "" }
 
     var query = [
@@ -32,11 +28,7 @@ public struct Keychain {
     return Keychain.query(.Fetch, query).1
   }
 
-  public static func setPassword(password: String, forAccount account: String, service: String = bundleIdentifier) -> Bool {
-    return setPassword(password, forAccount: account, service: service, accessGroup: "")
-  }
-  
-  public static func setPassword(password: String, forAccount account: String, service: String = bundleIdentifier, accessGroup: String) -> Bool {
+  public static func setPassword(password: String, forAccount account: String, service: String = bundleIdentifier, accessGroup: String = "") -> Bool {
     guard !service.isEmpty && !account.isEmpty else { return false }
 
     var query = [


### PR DESCRIPTION
We had two `password` and `setPassword` methods.

Now we only have one of each and the last label `accessGroup` defaults to an empty string so nothing should change for the user.
